### PR TITLE
add nidm-jsonld as submodule, closes #9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nidm-jsonld"]
+	path = nidm-jsonld
+	url = https://github.com/satra/nidm-jsonld.git


### PR DESCRIPTION
related to #9, I'm adding the repository at https://github.com/satra/nidm-jsonld as a submodule -- we can't put it into `requirements.txt` because it is not a python package. A submodule is probably the closest we'll get.