### PR TITLE
retrieve freesurfer version, if available

### DIFF
--- a/segstats_jsonld/fs_to_nidm.py
+++ b/segstats_jsonld/fs_to_nidm.py
@@ -348,11 +348,12 @@ def read_buildstamp(subdir):
                 freesurfer_version = f.readlines()[0]
         # except a FileNotFound error
         except OSError as e:
-            print("""
+            freesurfer_version = input(
+                """
                 Could not find a build timestamp in the supplied subject directory.
-                The used freesurfer version can not be extracted.
-                """)
-            freesurfer_version = ""
+                The used freesurfer version can not be extracted. Please enter the
+                version of freesurfer you are using, if available: """
+                or "")
     return freesurfer_version
 
 

--- a/segstats_jsonld/fs_to_nidm.py
+++ b/segstats_jsonld/fs_to_nidm.py
@@ -352,7 +352,7 @@ def read_buildstamp(subdir):
                 Could not find a build timestamp in the supplied subject directory.
                 The used freesurfer version can not be extracted.
                 """)
-
+            freesurfer_version = ""
     return freesurfer_version
 
 

--- a/segstats_jsonld/fs_to_nidm.py
+++ b/segstats_jsonld/fs_to_nidm.py
@@ -336,6 +336,25 @@ def add_seg_data(nidmdoc, measure, header, json_map, png_file=None, output_file=
                                 nidm_graph.add((datum_entity,region_entity,Literal(items['value'])))
 
 
+def read_buildstamp(subdir):
+    """
+    if provided with a freesurfer subject directory, check whether the build_stamp.txt file
+    exists, and if so, extract the freesurfer version.
+    :param subdir: path to subject directory, e.g. args.subject_dir
+    """
+    if os.path.exists(subdir):
+        try:
+            with open(subdir + '/scripts/build-stamp.txt', 'r') as f:
+                freesurfer_version = f.readlines()[0]
+        # except a FileNotFound error
+        except OSError as e:
+            print("""
+                Could not find a build timestamp in the supplied subject directory.
+                The used freesurfer version can not be extracted.
+                """)
+
+    return freesurfer_version
+
 
 
 
@@ -885,7 +904,8 @@ def main():
 
     # if we set -s or --subject_dir as parameter on command line...
     if args.subject_dir is not None:
-
+        # get the freesurfer version for later use
+        freesurfer_version = read_buildstamp(args.subject_dir)
         # files=['aseg.stats']
         for stats_file in glob.glob(os.path.join(args.subject_dir,"stats","*.stats")):
             if basename(stats_file) in supported_files:


### PR DESCRIPTION
adds a simple function to get the freesufer version from a recon-all in build_stamps.txt, if it can't find one it will ask for user help, and defaults to `" "` if nothing is provided.

The function isn't used anywhere yet. I'm not sure whether any tool already extracts the version, so let me know if thats a duplication.