### PR TITLE
Uberon

### DIFF
--- a/segstats_jsonld/fs_to_nidm.py
+++ b/segstats_jsonld/fs_to_nidm.py
@@ -677,7 +677,11 @@ def remap2json(xlsxfile,
         # store missing values as empty strings, not NaNs that json can't parse
         label = row['Atlas Segmentation Label'].values[0] if row['Atlas Segmentation Label'].values[0] is not np.nan else ""
         url = row['Structure']['URI'] if row['Structure']['URI'] is not np.nan else ""
-        isAbout = row['Structure']['Preferred'] if row['Structure']['Preferred'] is not np.nan else ""
+        # the UBERON ID is currently listed as a string (e.g. UBERON:0014930) in the Excel file, we want
+        # an URI such as http://purl.obolibrary.org/obo/UBERON_0014930
+        # TODO: is the base URL correct here? (is it static and can be hardcoded?)
+        isAbout = 'http://purl.obolibrary.org/obo/' + row['Structure']['Preferred'].replace(':', '_') \
+            if row['Structure']['Preferred'] is not np.nan else ""
         hasLaterality = row['Laterality']['ILX:0106135'] if row['Laterality']['ILX:0106135'] is not np.nan else ""
         l = row['Federated DE']['Name'] if row['Federated DE']['Name'] is not np.nan else ""
         # WIP: Added by DBK because I can't change the Name column or really edit the ReproNimCDEs.xlsx file at all
@@ -700,7 +704,7 @@ def remap2json(xlsxfile,
             if row['APARC Structures - Assuming Cortical Areas (not sulci)']['Label'] is not np.nan else ""
         url = row['APARC Structures - Assuming Cortical Areas (not sulci)']['URI'] \
             if row['APARC Structures - Assuming Cortical Areas (not sulci)']['URI'] is not np.nan else ""
-        isAbout = row['APARC Structures - Assuming Cortical Areas (not sulci)']['Preferred'] \
+        isAbout = 'http://purl.obolibrary.org/obo/' + row['APARC Structures - Assuming Cortical Areas (not sulci)']['Preferred'].replace(':', '_') \
             if row['APARC Structures - Assuming Cortical Areas (not sulci)']['Preferred']  is not np.nan else ""
         # TODO: The Laterality of the terms in aparc files is undefined yet. I think that should change
         hasLaterality = ""

--- a/segstats_jsonld/mapping_data/freesurfermap.json
+++ b/segstats_jsonld/mapping_data/freesurfermap.json
@@ -1,0 +1,853 @@
+{
+    "Anatomy": {
+        "Left-Lateral-Ventricle": {
+            "url": "http://uri.interlex.org/ILX:0106125",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002285",
+            "hasLaterality": "Left",
+            "definition": "lateral ventricle cerebral spinal fluid",
+            "label": "lateral ventricle"
+        },
+        "Left-Inf-Lat-Vent": {
+            "url": "http://uri.interlex.org/ILX:0105444",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006091",
+            "hasLaterality": "Left",
+            "definition": "inferior horn of the lateral ventricle cerebral spinal fluid",
+            "label": "inferior horn of the lateral ventricle"
+        },
+        "Left-Cerebellum-White-Matter": {
+            "url": "http://uri.interlex.org/ILX:0101963",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002037",
+            "hasLaterality": "Left",
+            "definition": "cerebellum white matter",
+            "label": "cerebellum white matter"
+        },
+        "Left-Cerebellum-Cortex": {
+            "url": "http://uri.interlex.org/ILX:0101946",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002129",
+            "hasLaterality": "Left",
+            "definition": "cerebellar cortex gray matter",
+            "label": "cerebellar cortex"
+        },
+        "Left-Thalamus-Proper": {
+            "url": "http://uri.interlex.org/ILX:0111657",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001897",
+            "hasLaterality": "Left",
+            "definition": "thalamus gray matter",
+            "label": "thalamus"
+        },
+        "Left-Caudate": {
+            "url": "http://uri.interlex.org/ILX:0101734",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001873",
+            "hasLaterality": "Left",
+            "definition": "caudate nucleus gray matter",
+            "label": "caudate nucleus"
+        },
+        "Left-Putamen": {
+            "url": "http://uri.interlex.org/ILX:0109549",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001874",
+            "hasLaterality": "Left",
+            "definition": "putamen gray matter",
+            "label": "putamen"
+        },
+        "Left-Pallidum": {
+            "url": "http://uri.interlex.org/ILX:0381379",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006514",
+            "hasLaterality": "Left",
+            "definition": "pallidum gray matter",
+            "label": "pallidum"
+        },
+        "3rd-Ventricle": {
+            "url": "http://uri.interlex.org/ILX:0111707",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002286",
+            "hasLaterality": "None",
+            "definition": "third ventricle cerebral spinal fluid",
+            "label": "third ventricle"
+        },
+        "4th-Ventricle": {
+            "url": "http://uri.interlex.org/ILX:0104381",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002422",
+            "hasLaterality": "None",
+            "definition": "fourth ventricle cerebral spinal fluid",
+            "label": "fourth ventricle"
+        },
+        "Brain-Stem": {
+            "url": "http://uri.interlex.org/ILX:0101444",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002298",
+            "hasLaterality": "None",
+            "definition": "brainstem gray matter",
+            "label": "brainstem"
+        },
+        "Left-Hippocampus": {
+            "url": "http://uri.interlex.org/ILX:0105021",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001954",
+            "hasLaterality": "Left",
+            "definition": "hippocampus gray matter",
+            "label": "hippocampus"
+        },
+        "Left-Amygdala": {
+            "url": "http://uri.interlex.org/ILX:0100573",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001876",
+            "hasLaterality": "Left",
+            "definition": "amygdala gray matter",
+            "label": "amygdala"
+        },
+        "CSF": {
+            "url": "http://uri.interlex.org/ILX:0102003",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001869",
+            "hasLaterality": "None",
+            "definition": "cerebrum cerebral spinal fluid",
+            "label": "cerebrum cerebral spinal fluid"
+        },
+        "Left-Accumbens-area": {
+            "url": "http://uri.interlex.org/ILX:0107736",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001882",
+            "hasLaterality": "Left",
+            "definition": "nucleus accumbens gray matter",
+            "label": "nucleus accumbens"
+        },
+        "Left-VentralDC": {
+            "url": "http://uri.interlex.org/ILX:0112300",
+            "isAbout": "",
+            "hasLaterality": "Left",
+            "definition": "ventral diencephalon gray matter",
+            "label": "ventral diencephalon gray matter"
+        },
+        "Left-vessel": {
+            "url": "http://uri.interlex.org/ILX:0381378",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0014930",
+            "hasLaterality": "Left",
+            "definition": "perivascular space blood",
+            "label": "perivascular space"
+        },
+        "Left-choroid-plexus": {
+            "url": "http://uri.interlex.org/ILX:0102142",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001886",
+            "hasLaterality": "Left",
+            "definition": "choroid plexus gray matter",
+            "label": "choroid plexus"
+        },
+        "Right-Lateral-Ventricle": {
+            "url": "http://uri.interlex.org/ILX:0106125",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002285",
+            "hasLaterality": "Right",
+            "definition": "lateral ventricle cerebral spinal fluid",
+            "label": "lateral ventricle"
+        },
+        "Right-Inf-Lat-Vent": {
+            "url": "http://uri.interlex.org/ILX:0105444",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006091",
+            "hasLaterality": "Right",
+            "definition": "inferior horn of the lateral ventricle cerebral spinal fluid",
+            "label": "inferior horn of the lateral ventricle"
+        },
+        "Right-Cerebellum-White-Matter": {
+            "url": "http://uri.interlex.org/ILX:0101963",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002037",
+            "hasLaterality": "Right",
+            "definition": "cerebellum white matter",
+            "label": "cerebellum white matter"
+        },
+        "Right-Cerebellum-Cortex": {
+            "url": "http://uri.interlex.org/ILX:0101946",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002129",
+            "hasLaterality": "Right",
+            "definition": "cerebellar cortex gray matter",
+            "label": "cerebellar cortex"
+        },
+        "Right-Thalamus-Proper": {
+            "url": "http://uri.interlex.org/ILX:0111657",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001897",
+            "hasLaterality": "Right",
+            "definition": "thalamus gray matter",
+            "label": "thalamus"
+        },
+        "Right-Caudate": {
+            "url": "http://uri.interlex.org/ILX:0101734",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001873",
+            "hasLaterality": "Right",
+            "definition": "caudate nucleus gray matter",
+            "label": "caudate nucleus"
+        },
+        "Right-Putamen": {
+            "url": "http://uri.interlex.org/ILX:0109549",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001874",
+            "hasLaterality": "Right",
+            "definition": "putamen gray matter",
+            "label": "putamen"
+        },
+        "Right-Pallidum": {
+            "url": "http://uri.interlex.org/ILX:0381379",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006514",
+            "hasLaterality": "Right",
+            "definition": "pallidum gray matter",
+            "label": "pallidum"
+        },
+        "Right-Hippocampus": {
+            "url": "http://uri.interlex.org/ILX:0105021",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001954",
+            "hasLaterality": "Right",
+            "definition": "hippocampus gray matter",
+            "label": "hippocampus"
+        },
+        "Right-Amygdala": {
+            "url": "http://uri.interlex.org/ILX:0100573",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001876",
+            "hasLaterality": "Right",
+            "definition": "amygdala gray matter",
+            "label": "amygdala"
+        },
+        "Right-Accumbens-area": {
+            "url": "http://uri.interlex.org/ILX:0107736",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001882",
+            "hasLaterality": "Right",
+            "definition": "nucleus accumbens gray matter",
+            "label": "nucleus accumbens"
+        },
+        "Right-VentralDC": {
+            "url": "http://uri.interlex.org/ILX:0112300",
+            "isAbout": "",
+            "hasLaterality": "Right",
+            "definition": "ventral diencephalon gray matter",
+            "label": "ventral diencephalon gray matter"
+        },
+        "Right-vessel": {
+            "url": "http://uri.interlex.org/ILX:0381378",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0014930",
+            "hasLaterality": "Right",
+            "definition": "perivascular space blood",
+            "label": "perivascular space"
+        },
+        "Right-choroid-plexus": {
+            "url": "http://uri.interlex.org/ILX:0102142",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001886",
+            "hasLaterality": "Right",
+            "definition": "choroid plexus gray matter",
+            "label": "choroid plexus"
+        },
+        "5th-Ventricle": {
+            "url": "http://uri.interlex.org/ILX:0381380",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0009857",
+            "hasLaterality": "None",
+            "definition": "cavum septum pellucidum cerebral spinal fluid",
+            "label": "cavum septum pellucidum"
+        },
+        "WM-hypointensities": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "None",
+            "definition": "NA",
+            "label": ""
+        },
+        "Left-WM-hypointensities": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "Left",
+            "definition": "NA",
+            "label": ""
+        },
+        "Right-WM-hypointensities": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "Right",
+            "definition": "NA",
+            "label": ""
+        },
+        "non-WM-hypointensities": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "None",
+            "definition": "NA",
+            "label": ""
+        },
+        "Left-non-WM-hypointensities": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "Left",
+            "definition": "NA",
+            "label": ""
+        },
+        "Right-non-WM-hypointensities": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "Right",
+            "definition": "NA",
+            "label": ""
+        },
+        "Optic-Chiasm": {
+            "url": "http://uri.interlex.org/ILX:0108069",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0000959",
+            "hasLaterality": "None",
+            "definition": "optic chiasm white matter",
+            "label": "optic chiasm"
+        },
+        "CC_Posterior": {
+            "url": "http://uri.interlex.org/ILX:0102562",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002336",
+            "hasLaterality": "None",
+            "definition": "NA",
+            "label": ""
+        },
+        "CC_Mid_Posterior": {
+            "url": "http://uri.interlex.org/ILX:0102562",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002336",
+            "hasLaterality": "None",
+            "definition": "NA",
+            "label": ""
+        },
+        "CC_Central": {
+            "url": "http://uri.interlex.org/ILX:0102562",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002336",
+            "hasLaterality": "None",
+            "definition": "NA",
+            "label": ""
+        },
+        "CC_Mid_Anterior": {
+            "url": "http://uri.interlex.org/ILX:0102562",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002336",
+            "hasLaterality": "None",
+            "definition": "NA",
+            "label": ""
+        },
+        "CC_Anterior": {
+            "url": "http://uri.interlex.org/ILX:0102562",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002336",
+            "hasLaterality": "None",
+            "definition": "NA",
+            "label": ""
+        },
+        "lhCortexVol": {
+            "url": "http://uri.interlex.org/ILX:0101978",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0000956",
+            "hasLaterality": "Left",
+            "definition": "cerebral cortex gray matter",
+            "label": "cerebral cortex"
+        },
+        "rhCortexVol": {
+            "url": "http://uri.interlex.org/ILX:0101978",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0000956",
+            "hasLaterality": "Right",
+            "definition": "cerebral cortex gray matter",
+            "label": "cerebral cortex"
+        },
+        "CortexVol": {
+            "url": "http://uri.interlex.org/ILX:0101978",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0000956",
+            "hasLaterality": "None",
+            "definition": "cerebral cortex gray matter",
+            "label": "cerebral cortex"
+        },
+        "lhCorticalWhiteMatterVol": {
+            "url": "http://uri.interlex.org/ILX:0102003",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001869",
+            "hasLaterality": "Left",
+            "definition": "cerebrum white matter",
+            "label": "cerebrum white matter"
+        },
+        "rhCorticalWhiteMatterVol": {
+            "url": "http://uri.interlex.org/ILX:0102003",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001869",
+            "hasLaterality": "Right",
+            "definition": "cerebrum white matter",
+            "label": "cerebrum white matter"
+        },
+        "CorticalWhiteMatterVol": {
+            "url": "http://uri.interlex.org/ILX:0102003",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001869",
+            "hasLaterality": "None",
+            "definition": "cerebrum white matter",
+            "label": "cerebrum white matter"
+        },
+        "SubCortGrayVol": {
+            "url": "http://uri.interlex.org/ILX:0101431",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0000955",
+            "hasLaterality": "None",
+            "definition": "part of brain gray matter",
+            "label": "sub-cortical gray matter"
+        },
+        "TotalGrayVol": {
+            "url": "http://uri.interlex.org/ILX:0101431",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0000955",
+            "hasLaterality": "None",
+            "definition": "brain gray matter",
+            "label": "brain gray matter"
+        },
+        "SupraTentorialVol": {
+            "url": "http://uri.interlex.org/ILX:0102003",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001869",
+            "hasLaterality": "None",
+            "definition": "cerebrum tissue",
+            "label": "cerebrum tissue"
+        },
+        "IntraCranialVol": {
+            "url": "http://uri.interlex.org/ILX:0381382",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0003128",
+            "hasLaterality": "None",
+            "definition": "within cranium tissue",
+            "label": "intra-cranium"
+        },
+        "Left-Cerebral-Exterior": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "Left",
+            "definition": "NA",
+            "label": ""
+        },
+        "Left-Cerebral-White-Matter": {
+            "url": "http://uri.interlex.org/ILX:0102003",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001869",
+            "hasLaterality": "Left",
+            "definition": "cerebrum white matter",
+            "label": "cerebrum white matter"
+        },
+        "Left-Cerebral-Cortex": {
+            "url": "http://uri.interlex.org/ILX:0101978",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0000956",
+            "hasLaterality": "Left",
+            "definition": "cerebral cortex gray matter",
+            "label": "cerebral cortex"
+        },
+        "Left-Cerebellum-Exterior": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "",
+            "definition": "NA",
+            "label": ""
+        },
+        "Left-Thalamus": {
+            "url": "http://uri.interlex.org/ILX:0111657",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001897",
+            "hasLaterality": "Left",
+            "definition": "thalamus gray matter",
+            "label": "thalamus"
+        },
+        "Left-Insula": {
+            "url": "http://uri.interlex.org/ILX:0105519",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002022",
+            "hasLaterality": "Left",
+            "definition": "insula gray matter",
+            "label": "insula"
+        },
+        "Left-Operculum": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "Left",
+            "definition": "NA",
+            "label": ""
+        },
+        "Left-Lesion": {
+            "url": "http://uri.interlex.org/ILX:0102003",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001869",
+            "hasLaterality": "Left",
+            "definition": "cerebrum lesion",
+            "label": "cerebrum lesion"
+        },
+        "Left-Substantia-Nigra": {
+            "url": "http://uri.interlex.org/ILX:0111214",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002038",
+            "hasLaterality": "Left",
+            "definition": "substantia nigra gray matter",
+            "label": "substantia nigra"
+        },
+        "Right-Cerebral-Exterior": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "",
+            "definition": "NA",
+            "label": ""
+        },
+        "Right-Cerebral-White-Matter": {
+            "url": "http://uri.interlex.org/ILX:0102003",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001869",
+            "hasLaterality": "Right",
+            "definition": "cerebrum white matter",
+            "label": "cerebrum white matter"
+        },
+        "Right-Cerebral-Cortex": {
+            "url": "http://uri.interlex.org/ILX:0101978",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0000956",
+            "hasLaterality": "Right",
+            "definition": "cerebral cortex gray matter",
+            "label": "cerebral cortex"
+        },
+        "Right-Cerebellum-Exterior": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "",
+            "definition": "NA",
+            "label": ""
+        },
+        "Right-Thalamus": {
+            "url": "http://uri.interlex.org/ILX:0111657",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001897",
+            "hasLaterality": "Right",
+            "definition": "thalamus gray matter",
+            "label": "thalamus"
+        },
+        "Right-Insula": {
+            "url": "http://uri.interlex.org/ILX:0105519",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002022",
+            "hasLaterality": "Right",
+            "definition": "insula gray matter",
+            "label": "insula"
+        },
+        "Right-Operculum": {
+            "url": "",
+            "isAbout": "",
+            "hasLaterality": "Right",
+            "definition": "NA",
+            "label": ""
+        },
+        "Right-Lesion": {
+            "url": "http://uri.interlex.org/ILX:0102003",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001869",
+            "hasLaterality": "Right",
+            "definition": "cerebrum lesion",
+            "label": "cerebrum lesion"
+        },
+        "Right-Substantia-Nigra": {
+            "url": "http://uri.interlex.org/ILX:0111214",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002038",
+            "hasLaterality": "Right",
+            "definition": "substantia nigra gray matter",
+            "label": "substantia nigra"
+        },
+        "Left-Amygdala-Anterior": {
+            "url": "http://uri.interlex.org/ILX:0100573",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001876",
+            "hasLaterality": "Left",
+            "definition": "NA",
+            "label": ""
+        },
+        "Right-Amygdala-Anterior": {
+            "url": "http://uri.interlex.org/ILX:0100573",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0001876",
+            "hasLaterality": "Right",
+            "definition": "NA",
+            "label": ""
+        },
+        "Dura": {
+            "url": "http://uri.interlex.org/ILX:0103596",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002363",
+            "hasLaterality": "None",
+            "definition": "dura mater tissue",
+            "label": "dura mater tissue"
+        },
+        "Corpus-Callosum": {
+            "url": "http://uri.interlex.org/ILX:0102562",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002336",
+            "hasLaterality": "None",
+            "definition": "corpus callosum white matter",
+            "label": "corpus callosum"
+        },
+        "Right-Vessel": {
+            "url": "http://uri.interlex.org/ILX:0381378",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0014930",
+            "hasLaterality": "Right",
+            "definition": "perivascular space blood",
+            "label": "perivascular space"
+        },
+        "Left-Basal-Forebrain": {
+            "url": "http://uri.interlex.org/ILX:0101101",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002743",
+            "hasLaterality": "Left",
+            "definition": "basal forebrain gray matter",
+            "label": "basal forebrain gray matter"
+        },
+        "Right-Basal-Forebrain": {
+            "url": "http://uri.interlex.org/ILX:0101101",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002743",
+            "hasLaterality": "Right",
+            "definition": "basal forebrain gray matter",
+            "label": "basal forebrain gray matter"
+        },
+        "cerebellar vermal lobules I-V": {
+            "url": "http://uri.interlex.org/ILX:0112407",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0004720",
+            "hasLaterality": "None",
+            "definition": "NA",
+            "label": ""
+        },
+        "cerebellar vermal lobules VI-VII": {
+            "url": "http://uri.interlex.org/ILX:0112407",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0004720",
+            "hasLaterality": "None",
+            "definition": "NA",
+            "label": ""
+        },
+        "cerebellar vermal lobules VIII-X": {
+            "url": "http://uri.interlex.org/ILX:0112407",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0004720",
+            "hasLaterality": "None",
+            "definition": "NA",
+            "label": ""
+        },
+        "bankssts": {
+            "url": "http://uri.interlex.org/base/ilx_0101088",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0028622",
+            "hasLaterality": "",
+            "definition": "Component of the temporal lobe, lateral aspect.  The rostral boundary is the superior temporal gyrus and the caudal boundary the middle temporal gyrus.  Within the FreeSurfer definition, this reflects primarily the posterior aspect of the superior temporal sulcus (Christine Fennema-Notestine).",
+            "label": "Banks of superior temporal sulcus"
+        },
+        "caudalanteriorcingulate ": {
+            "url": "http://uri.interlex.org/base/ilx_0101709",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0028715",
+            "hasLaterality": "",
+            "definition": "Component of the cingulate cortex.  The rostral boundary was the first appearance of the genu of the corpus callosum whereas the caudal boundary was established as the first appearance of the mammillary bodies. The medial boundary was the medial aspect of the cortex. The supero-lateral boundary was the superior frontal gyrus whereas the infero-lateral boundary was the corpus callosum (Christine Fennema-Notestine).",
+            "label": "Caudal anterior cingulate cortex"
+        },
+        "caudalmiddlefrontal": {
+            "url": "http://uri.interlex.org/base/ilx_0101718",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006445",
+            "hasLaterality": "",
+            "definition": "Component of the middl frontal gyrus.  The rostral boundary of the middle frontal gyrus was the rostral extent of the middle frontal gyrus whereas the caudal boundary was the precentral gyrus. The medial and lateral boundaries were designated as the superior frontal sulcus and the inferior frontal sulcus respectively (Christine Fennema-Notestine).",
+            "label": "Caudal middle frontal gyrus"
+        },
+        "cuneus": {
+            "url": "http://uri.interlex.org/base/ilx_0102674",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006092",
+            "hasLaterality": "",
+            "definition": "Component of the occipital lobe.  The rostral boundary was the first coronal slice above the calcarine sulcus where the cuneus cortex becomes visible whereas the caudal boundary was the last slice where the calcarine sulcus was visualized. The medial boundary was the most medial portion of the occipital and parietal cortices. The superio-lateral boundary was the parieto-occipital fissure whereas the inferolateral boundary was the pericalcarine cortex (Christine Fennema-Notestine).",
+            "label": "Cuneus cortex "
+        },
+        "entorhinal": {
+            "url": "http://uri.interlex.org/base/ilx_0103859",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002728",
+            "hasLaterality": "",
+            "definition": "Component of the temporal lobe on the mesial surface.  The rostral and caudal boundaries of the entorhinal cortex are the rostral end of the collateral sulcus and the caudal end of the amygdala respectively.  The medial boundary is the medial aspect of the temporal lobe and the lateral boundary is the collateral sulcus. (DK)",
+            "label": "Entorhinal cortex"
+        },
+        "fusiform": {
+            "url": "http://uri.interlex.org/base/ilx_0104491",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002766",
+            "hasLaterality": "",
+            "definition": "",
+            "label": "Fusiform gyrus"
+        },
+        "inferiorparietal": {
+            "url": "http://uri.interlex.org/base/ilx_0105452",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006088",
+            "hasLaterality": "",
+            "definition": "Component of the parietal lobe.  The inferior parietal cortex label includes the inferior parietal gyrus and the angular gyrus and lies inferior to the superior parietal gyrus. The rostral and caudal boundaries were the supramarginal gyrus and the parieto-occipital incisure respectively. The medial and lateral boundaries were the superior parietal gyrus and the middle temporal gyrus respectively (Christine Fennema-Notestine).",
+            "label": "Inferior parietal cortex"
+        },
+        "inferiortemporal": {
+            "url": "http://uri.interlex.org/base/ilx_0105463",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002751",
+            "hasLaterality": "",
+            "definition": "Component of the temporal lobe, lateral aspect.  The rostral boundary is the rostral extent of the inferior temporal sulcus whereas the caudal boundary is designated as the temporo-occipital incisure on the cortical surface. The occipitotemporal sulcus is the medial boundary and the inferior temporal sulcus is the lateral boundary (Christine Fennema-Notestine).",
+            "label": "Inferior temporal gyrus"
+        },
+        "isthmuscingulate": {
+            "url": "http://uri.interlex.org/base/ilx_0728891",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0027061",
+            "hasLaterality": "",
+            "definition": "",
+            "label": "isthmus of cingulate cortex"
+        },
+        "lateraloccipital": {
+            "url": "http://uri.interlex.org/base/ilx_0106080",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006114",
+            "hasLaterality": "",
+            "definition": "Component of the occipital lobe.  The rostral and caudal boundaries of the lateral occipital cortex were the superior parietal gyrus and as the last visible portion of occipital cortex respectively. The medial and lateral boundaries were the cuneus/pericalcarine cortex and the inferior temporal/inferior parietal gyri respectively (Christine Fennema-Notestine).",
+            "label": "Lateral occipital cortex"
+        },
+        "lateralorbitofrontal": {
+            "url": "http://uri.interlex.org/base/ilx_0106083",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0022716",
+            "hasLaterality": "",
+            "definition": "Component of the orbtial frontal cortex The rostral boundary is the first slice where the lateral orbital gyrus is apparent with the frontomarginal sulcus whereas the caudal boundary is the disappearance of the lateral orbital gyrus. The medial and lateral boundaries are the midpoint of the olfactory sulcus and the lateral bank of the lateral orbital sulcus and/or the circular insular sulcus respectively (Christine Fennema-Notestine).",
+            "label": "Lateral orbital frontal cortex"
+        },
+        "lingual": {
+            "url": "http://uri.interlex.org/base/ilx_0106278",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002943",
+            "hasLaterality": "",
+            "definition": "Component of the occipital lobe.  The rostral boundary of the lingual gyrus was the posterior extent of the parahippocampal gyrus whereas the caudal boundary was the most posterior coronal slice where the gyrus could be visualized. The medial and lateral boundaries were the medial portion of the temporal and occipital cortices and the medial bank of the collateral sulcus respectively (Christine Fennema-Notestine).",
+            "label": "Lingual gyrus"
+        },
+        "medialorbitofrontal": {
+            "url": "http://uri.interlex.org/base/ilx_0106672",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0022352",
+            "hasLaterality": "",
+            "definition": "Component of the orbtial frontal cortex.  The rostral boundary is the first slice where the medial orbital gyrus became visible whereas the caudal boundary is the disappearance of the medial orbital gyrus/gyrus rectus. The medial and lateral boundaries are the cingulate cortex on the u2018inflatedu2019 surface and the medial bank of the superior frontal gyrus (or the cingulate gyrus when visible) respectively (Christine Fennema-Notestine).",
+            "label": "Medial orbital frontal cortex "
+        },
+        "middletemporal": {
+            "url": "http://uri.interlex.org/base/ilx_0106967",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002771",
+            "hasLaterality": "",
+            "definition": "Component of the temporal lobe, lateral aspect.  The rostral boundary  is the rostral extent of the superior temporal sulcus whereas the caudal boundary is the temporo-occipital incisure on the cortical surface. The superior temporal sulcus is the medial boundary and the inferior temporal sulcus is the lateral boundary (Christine Fennema-Notestine).",
+            "label": "Middle temporal gyrus"
+        },
+        "parahippocampal": {
+            "url": "http://uri.interlex.org/base/ilx_0108441",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002973",
+            "hasLaterality": "",
+            "definition": "Component of the temporal lobe on the mesial surface, posterior to the entorhinal cortex. The rostral and caudal boundaries are the posterior end of the netorhinal cortex and the caudal portion of the hippocampus, respectively.  The medial boudnary is designated as the medial aspect off the temporal lobe and the lateral boundary is the collateral sulcus (Christine Fennema-Notestine).",
+            "label": "Parahippocampal gyrus "
+        },
+        "paracentral": {
+            "url": "http://uri.interlex.org/base/ilx_0737027",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0007190",
+            "hasLaterality": "",
+            "definition": "",
+            "label": "paracentral gyrus"
+        },
+        "parsopercularis": {
+            "url": "http://uri.interlex.org/base/ilx_0108057",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002980",
+            "hasLaterality": "",
+            "definition": "Component of the inferior frontal gyrus.defined as the first gyrus from the precentral gyrus.",
+            "label": "Opercular part of inferior frontal gyrus"
+        },
+        "parsorbitalis": {
+            "url": "http://uri.interlex.org/base/ilx_0108113",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002624",
+            "hasLaterality": "",
+            "definition": "Component of the inferior frontal gyrus.defined as the first gyrus from the precentral gyrus.the remainder of the inferior frontal gyrus once the pars opercularis and triangularis have been defined (Christine Fennema-Notestine)., NeuroNames",
+            "label": "Orbital part of inferior frontal gyrus"
+        },
+        "parstriangularis": {
+            "url": "http://uri.interlex.org/base/ilx_0111954",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002629",
+            "hasLaterality": "",
+            "definition": "Component of the inferior frontal gyrus.defined as the second gyrus from the precentral gyrus (Christine Fennema-Notestine).",
+            "label": "Triangular part of inferior frontal gyrus"
+        },
+        "pericalcarine": {
+            "url": "http://uri.interlex.org/base/ilx_0108719",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0022534",
+            "hasLaterality": "",
+            "definition": "Component of the parietal lobe.  The rostral boundary of the pericalcarine cortex was the first appearance of the calcarine sulcus whereas the caudal boundary was the most posterior coronal slice where the calcarine sulcus was visualized. The medial and lateral boundaries were the medial portion of the temporal and occipital cortices and the inferomedial end of the calcarine sulcus respectively (Christine Fennema-Notestine).",
+            "label": "Pericalcarine cortex"
+        },
+        "postcentral": {
+            "url": "http://uri.interlex.org/base/ilx_0109070",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002581",
+            "hasLaterality": "",
+            "definition": "Component of the parietal lobe.  The appearance and disappearance of the central sulcus were the rostral and caudal boundaries of the postcentral gyrus respectively.  The medial and lateral boundaries were the lateral bank of the precentral gyrus and the lateral fissure and/or the medial bank of the superior parietal gyrus respectively (Christine Fennema-Notestine).",
+            "label": "Postcentral gyrus"
+        },
+        "posteriorcingulate": {
+            "url": "http://uri.interlex.org/base/ilx_0109087",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0022353",
+            "hasLaterality": "",
+            "definition": "Component of the cingulate cortex. The rostral and caudal extent were the caudal anterior and the isthmus divisions of the cingulate cortex respectively. The medial and lateral boundaries were the corpus callosum and as the superior frontal gyrus and/or paracentral lobule respectively (Christine Fennema-Notestine).",
+            "label": "Posterior cingulate cortex"
+        },
+        "precentral": {
+            "url": "http://uri.interlex.org/base/ilx_0109193",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002703",
+            "hasLaterality": "",
+            "definition": "Component of the frontal lobe.  The appearance and disappearance of the central sulcus is the rostral and caudal boundaries of the precentral gyrus respectively. The medial boundary is specific frontal gyri (superior, middle and inferior) whereas the lateral boundary is the medial bank of the central sulcus (Christine Fennema-Notestine).",
+            "label": "Precentral gyrus"
+        },
+        "precuneus": {
+            "url": "http://uri.interlex.org/base/ilx_0109199",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006093",
+            "hasLaterality": "",
+            "definition": "Component of the parietal lobe.  The rostral boundary was the posterior extent of the paracentral lobule whereas the caudal boundary was the lingual gyrus. The medial and lateral boundaries were the parieto-occipital fissure and the superior parietal gyrus respectively (Christine Fennema-Notestine).",
+            "label": "Precuneus cortex"
+        },
+        "rostralanteriorcingulate": {
+            "url": "http://uri.interlex.org/base/ilx_0110204",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0022438",
+            "hasLaterality": "",
+            "definition": "Component of the cingulate cortex.  The rostral boundary was the first appearance of the cingulate sulcus (inferior to the superior frontal sulcus) whereas the caudal boundary was the first appearance of the genu of the corpus callosum. The medial boundary was the medial aspect of the cortex. The supero-lateral boundary was the superior frontal gyrus whereas the infero-lateral boundary was defined as the medial division of the orbitofrontal gyrus (Christine Fennema-Notestine).",
+            "label": "Rostral anterior cingulate cortex"
+        },
+        "rostralmiddlefrontal": {
+            "url": "http://uri.interlex.org/base/ilx_0110215",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006446",
+            "hasLaterality": "",
+            "definition": "Component of the middl frontal gyrus  The rostral boundary is the first appearance of the superior frontal sulcus whereas the caudal boundary is the middle frontal gyrus. The medial and lateral boundaries are the superior frontal sulcus and the inferior frontal sulcus respectively (Christine Fennema-Notestine).",
+            "label": "Rostral middle frontal gyrus"
+        },
+        "superiorfrontal": {
+            "url": "http://uri.interlex.org/base/ilx_0111304",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002661",
+            "hasLaterality": "",
+            "definition": "Component of the frontal lobe, lateral aspect.  The rostral boundary is the first appearance of the superior frontal sulcus whereas the caudal boundary is the midpoint of the paracentral sulcus on the \\",
+            "label": "Superior frontal gyrus"
+        },
+        "superiorparietal": {
+            "url": "http://uri.interlex.org/base/ilx_0111317",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0006094",
+            "hasLaterality": "",
+            "definition": "Component of the parietal lobe.  The rostral and caudal boundaries of the superior parietal cortex were the precentral gyrus and lateral occipital cortex respectively. The medial and lateral boundaries were the precuneus and/or cuneus cortex and the infererior parietal cortex respectively (Christine Fennema-Notestine).",
+            "label": "Superior parietal cortex"
+        },
+        "superiortemporal": {
+            "url": "http://uri.interlex.org/base/ilx_0111328",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002769",
+            "hasLaterality": "",
+            "definition": "Component of the temporal lobe, lateral aspect.  The rostral boundary is the rostral extent of the ssuperior temporal sulcus.  The caudal boundary is the cauday portion of the superior temporal gyrus (posterior to becoming continuous with the supramarginal gyrus).  The medial boundary is the lateral fissure (and when present the supramarginal gyrus), and the lateral boundary is the superior temporal suclus (Christine Fennema-Notestine).",
+            "label": "Superior temporal gyrus"
+        },
+        "supramarginal": {
+            "url": "http://uri.interlex.org/base/ilx_0111355",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002688",
+            "hasLaterality": "",
+            "definition": "Component of the parietal lobe.  The first coronal slice between the superior temporal gyrus and the postcentral gyrus where the supramarginal gyrus appears was the rostral boundary whereas the slice where the supramarginal gyrus becomes continuous with the superior parietal gyrus was the caudal boundary. The medial and lateral boundaries were the lateral banks of the intraparietal sulcus and the medial banks of the lateral fissure and/or the superior temporal gyrus respectively (Christine Fennema-Notestine).",
+            "label": "Supramarginal gyrus"
+        },
+        "frontalpole": {
+            "url": "http://uri.interlex.org/base/ilx_0104455",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002795",
+            "hasLaterality": "",
+            "definition": "Component of the frontal lobe.  The rostral and caudal boundaries of the frontal pole are the superior frontal gyrus and the rostral division of the middle frontal gyrus respectively in human (Christine Fennama-Notestine).",
+            "label": "Frontal Pole"
+        },
+        "temporalpole": {
+            "url": "http://uri.interlex.org/base/ilx_0111595",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002576",
+            "hasLaterality": "",
+            "definition": "Anterior component of the temporal lobe (rostral boundary) extends caudally to the entorhinal cortex.  The medial and lateral boundaries are the medial aspect of the temporal lobe and the superior or inferior temporal sulci, respectively (Christine Fennema-Notestine).",
+            "label": "Temporal Pole"
+        },
+        "transversetemporal": {
+            "url": "http://uri.interlex.org/base/ilx_0111910",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0003939",
+            "hasLaterality": "",
+            "definition": "Component of the temporal lobe, lateral aspect.  The rostral boundary is the first appearance of the transverse temporal sulcus whereas the caudal boundary is the last slice where the transverse temporal cortex could be identified before its merger into the insular cortex. The lateral fissure and the superior temporal gyrus are the medial and lateral boundaries respectively (Christine Fennema-Notestine).",
+            "label": "Transverse Temporal Cortex"
+        },
+        "insula": {
+            "url": "http://uri.interlex.org/base/ilx_0105519",
+            "isAbout": "http://purl.obolibrary.org/obo/UBERON_0002022",
+            "hasLaterality": "",
+            "definition": "Gray matter of the insular region of the neocortex. In gyrencephalic animals, it is part of the insular lobe and lies in the depths of the lateral fissure and covered by portions of the frontal, parietal and temporal lobes. It includes Brodmann areas 13-16.",
+            "label": "Insula (Insular Cortex)"
+        }
+    },
+    "Measures": {
+        "NVoxels": {
+            "measureOf": "http://uri.interlex.org/base/ilx_0105536#",
+            "datumType": "http://uri.interlex.org/base/ilx_0102597#"
+        },
+        "Volume_mm3": {
+            "measureOf": "http://uri.interlex.org/base/ilx_0105536#",
+            "datumType": "http://uri.interlex.org/base/ilx_0112559#"
+        },
+        "normMean": {
+            "measureOf": "http://uri.interlex.org/base/ilx_0105536#",
+            "datumType": "http://uri.interlex.org/base/ilx_0738264#"
+        },
+        "normStdDev": {
+            "measureOf": "http://uri.interlex.org/base/ilx_0105536#",
+            "datumType": "http://uri.interlex.org/base/ilx_0738265#"
+        },
+        "normMin": {
+            "measureOf": "http://uri.interlex.org/base/ilx_0105536#",
+            "datumType": "http://uri.interlex.org/base/ilx_0738266#"
+        },
+        "normMax": {
+            "measureOf": "http://uri.interlex.org/base/ilx_0105536#",
+            "datumType": "http://uri.interlex.org/base/ilx_0738267#"
+        },
+        "normRange": {
+            "measureOf": "http://uri.interlex.org/base/ilx_0105536#",
+            "datumType": "http://uri.interlex.org/base/ilx_0738268#"
+        }
+    }
+}


### PR DESCRIPTION
This should transform the UBERON IDs from the ReproNimCDEs excel sheet into URIs.
In [the excel sheet](https://docs.google.com/spreadsheets/d/1VcpNj1deZ7dF8XM6yXt5VWCNVVQkCnV9Y48wvMFYw0g/edit#gid=1737769619), UBERONs are displayed in format ``UBERON:0001874``, this would transform them into something like ``http://purl.obolibrary.org/obo/UBERON_0001874``.

This addresses parts of [this issue](https://github.com/dbkeator/simple2_NIDM_examples/issues/2).